### PR TITLE
Refactor Lunr.js usage for global context compatibility

### DIFF
--- a/data/js/search-ui.js
+++ b/data/js/search-ui.js
@@ -146,7 +146,6 @@
   searchResultContainer.classList.add('search-result-dropdown-menu');
   searchInput.parentNode.appendChild(searchResultContainer);
   const facetFilterInput = document.querySelector('#search-field input[type=checkbox][data-facet-filter]');
-  const lunr = require('lunr');
 
   function appendStylesheet (href) {
     if (!href) return
@@ -410,7 +409,7 @@
       const filteredDocuments = store.documents.filter((doc) => trieDocIds.has(doc.id));
       if (filteredDocuments.length > 0) {
         // Rebuild a temporary index only with the filtered documents
-        const tempLunrIndex = lunr(function () {
+        const tempLunrIndex = globalThis.lunr(function () {
           this.ref('id');
           this.field('title', { boost: 10 });
           this.field('name');


### PR DESCRIPTION
Removed local Lunr.js import and switched to using `globalThis.lunr`. This change ensures compatibility with the global context and avoids redundant module imports.